### PR TITLE
增加alibaba weex-ui 的重定向

### DIFF
--- a/weex-ui/index.html
+++ b/weex-ui/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="chrome=1" />
+    <meta
+      name="description"
+      content="Alibaba Open Source : The alibaba github homepage."
+    />
+    <title>Weex Ui</title>
+    <meta http-equiv="refresh" content="0; URL=https://apache.github.io/incubator-weex-ui/">
+<link rel="canonical" href="https://apache.github.io/incubator-weex-ui/">
+  </head>
+
+  <body></body>
+</html>


### PR DESCRIPTION
因为目前 [alibaba/weex-ui](https://github.com/alibaba/weex-ui/) 已经捐赠给 https://apache.github.io/incubator-weex-ui/ 啦
但是由于官方采用的是 github pages，导致原来的 https://alibaba.github.io/weex-ui/ 目前访问是错误页面，影响用户的使用，需要在此主体上面加一个对 weex-ui 官网的重定向到https://apache.github.io/incubator-weex-ui/#/
希望帮忙处理合并一下